### PR TITLE
Fixed Spectra versioning

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -4,6 +4,7 @@
     "name":         "Spectra",
     "abstract":     "A well optimized and yet breathtakingly beautiful revamp of all celestial bodies in KSP",
     "$kref":        "#/ckan/spacedock/1505",
+    "ksp_version_min": "1.1.2",
     "x_netkan_force_v": true,
     "license":      "MIT",
     "release_status": "stable",
@@ -49,13 +50,5 @@
     }, {
         "file":       "Step 2 - Spectra/GameData/KSPRC",
         "install_to": "GameData"
-    } ],
-    "x_netkan_override": [{
-        "version": "v1.1.3",
-        "delete":  [ "ksp_version" ],
-        "override": {
-            "ksp_version_min": "1.3",
-            "ksp_version_max": "1.3.99"
-        }
-    }]
+    } ]
 }


### PR DESCRIPTION
Removed versioning override and set ksp_version_min to 1.1.2 (creation of parent mod), excluded ksp_version_max so that there is no max version.